### PR TITLE
[DIGI - 17976] Poll continuing with invalid session key

### DIFF
--- a/sdk/src/main/java/me/digi/sdk/DMEPullClient.kt
+++ b/sdk/src/main/java/me/digi/sdk/DMEPullClient.kt
@@ -164,7 +164,7 @@ class DMEPullClient(val context: Context, val configuration: DMEPullConfiguratio
         }
         else {
             DMELog.e("Your session is invalid; please request a new one.")
-            completion(null, DMEAuthError.InvalidSession())
+            fileListCompletionHandler?.invoke(DMEAuthError.InvalidSession())
         }
     }
 


### PR DESCRIPTION
- FileList update was not stoped if session key is invalid, poll continues until it reaches timeout.
- Fix added to immediately invoke completion with error when session key is not valid.