### PR TITLE
Implementation of a notification that fires when we detect a digi.me installation.

### DIFF
--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
 
         </activity>
 
+        <activity android:name=".utilities.DMEResumeStateActivity"/>
+
         <receiver
                 android:name=".interapp.DMEInstallHandler"
                 android:enabled="true"

--- a/sdk/src/main/java/me/digi/sdk/DMEPullClient.kt
+++ b/sdk/src/main/java/me/digi/sdk/DMEPullClient.kt
@@ -1,7 +1,9 @@
 package me.digi.sdk
 
-import android.app.Activity
+import android.app.*
 import android.content.Context
+import android.graphics.drawable.Icon
+import android.os.Build
 import android.os.Handler
 import me.digi.sdk.callbacks.*
 import me.digi.sdk.callbacks.DMEFileListCompletion

--- a/sdk/src/main/java/me/digi/sdk/utilities/DMEDrawableUtils.kt
+++ b/sdk/src/main/java/me/digi/sdk/utilities/DMEDrawableUtils.kt
@@ -1,0 +1,22 @@
+package me.digi.sdk.utilities
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import kotlin.math.max
+
+internal object DMEDrawableUtils {
+
+    fun createBitmap(from: Drawable): Bitmap {
+        if (from is BitmapDrawable && from.bitmap != null) {
+            return from.bitmap
+        }
+
+        val bitmap = Bitmap.createBitmap(max(1, from.intrinsicWidth), max(1, from.intrinsicHeight), Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        from.setBounds(0, 0, canvas.width, canvas.height)
+        from.draw(canvas)
+        return bitmap
+    }
+}

--- a/sdk/src/main/java/me/digi/sdk/utilities/DMEResumeStateActivity.kt
+++ b/sdk/src/main/java/me/digi/sdk/utilities/DMEResumeStateActivity.kt
@@ -1,0 +1,12 @@
+package me.digi.sdk.utilities
+
+import android.app.Activity
+import android.os.Bundle
+
+class DMEResumeStateActivity: Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        finish()
+    }
+}

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -52,6 +52,11 @@
 
     <!-- Miscellaneous Constants -->
     <string name="const_digime_app_package_name">me.digi.app3</string>
+    <string name="const_android10_notification_channel_id">DigiMeCommunications</string>
+    <string name="const_android10_notification_channel_name">digi.me Communications</string>
+    <string name="const_android10_notification_title">digi.me is now installed!</string>
+    <string name="const_android10_notification_body">Tap here to finish onboarding.</string>
+    <string name="const_android10_notification_action">OPEN %1$s</string>
 
     <!-- Consent Mode Selection -->
     <string name="consent_mode_selection_heading"><b>Save time! Stay in control!</b></string>


### PR DESCRIPTION
 This is only necessary on Android 10 devices, due to the change Google made whereby backgrounded tasks can no longer launch activities and bring themselves to the foreground. This breaks CA Led Onboarding, so whilst we work on a permanent fix, this serves as a means of reducing the number of users getting lost.

[Preview the notification here.](https://streamable.com/s/rjitt/azkbep)