### PR TITLE
[DIGI 17992] CA Scope

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -6,12 +6,12 @@ apply from: 'config/gradle/versioning.gradle'
 apply from: 'config/gradle/coverage.gradle'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "$versions.sdk"
 
@@ -77,6 +77,9 @@ dependencies {
     testImplementation "org.robolectric:robolectric-shadows:$versions.robolectricshadows"
     androidTestImplementation "com.android.support.test:runner:$versions.testrunner"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$versions.espresso"
+
+    testImplementation "io.mockk:mockk:$versions.mockk"
+
 }
 
 repositories {

--- a/sdk/src/main/java/me/digi/sdk/api/adapters/DMESessionRequestAdapter.kt
+++ b/sdk/src/main/java/me/digi/sdk/api/adapters/DMESessionRequestAdapter.kt
@@ -1,14 +1,18 @@
 package me.digi.sdk.api.adapters
 
 import com.google.gson.*
-import me.digi.sdk.entities.DMEDataAcceptCondition
-import me.digi.sdk.entities.DMEDataRequest
+import me.digi.sdk.entities.*
 import me.digi.sdk.entities.api.DMESessionRequest
+import me.digi.sdk.utilities.DMELog
 import java.lang.reflect.Type
 
-object DMESessionRequestAdapter: JsonSerializer<DMESessionRequest> {
+object DMESessionRequestAdapter : JsonSerializer<DMESessionRequest> {
 
-    override fun serialize(src: DMESessionRequest?, typeOfSrc: Type?, context: JsonSerializationContext?): JsonElement {
+    override fun serialize(
+        src: DMESessionRequest?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement {
 
         val json = JsonObject()
 
@@ -30,30 +34,95 @@ object DMESessionRequestAdapter: JsonSerializer<DMESessionRequest> {
         return json
     }
 
+    private fun serializeTimeRanges(src: DMEDataRequest): JsonArray {
+        val timeRangesJSON = JsonArray()
+
+        if (src.timeRangesInitialized()) {
+            src.timeRanges.forEach { timeRange ->
+                val timeRangeJSON = JsonObject()
+
+                val timeFrom = timeRange.from
+                val timeTo = timeRange.to
+                val timeLast = timeRange.last
+                val timeType = timeRange.type
+
+                if (timeType != null) {
+                    timeRangeJSON.addProperty("type", timeType)
+                }
+
+                if (timeLast != null) {
+                    timeRangeJSON.addProperty("last", timeLast)
+                } else if (timeFrom != null && timeTo != null) {
+                    timeRangeJSON.addProperty("from", timeFrom.time)
+                    timeRangeJSON.addProperty("to", timeTo.time)
+                }
+
+                if (timeRangeJSON.size() > 0) {
+                    timeRangesJSON.add(timeRangeJSON)
+                }
+            }
+
+            if(timeRangesJSON.count() == 0)
+                DMELog.e("Invalid scope time ranges format.")
+
+            return timeRangesJSON
+        } else
+            return JsonArray()
+    }
+
+    private fun serializeServiceGroups(src: DMEDataRequest): JsonArray {
+        val serviceGroupsJSON = JsonArray()
+
+        if (src.serviceGroupsInitialized()) {
+
+            src.serviceGroups.forEach { serviceGroup ->
+                val serviceGroupJSON = JsonObject()
+                val serviceTypesJSON = JsonArray()
+
+                serviceGroupJSON.addProperty("id", serviceGroup.id)
+
+                serviceGroup.serviceTypes.forEach { serviceType ->
+                    val serviceTypeJSON = JsonObject()
+                    val serviceObjectTypesJSON = JsonArray()
+
+                    serviceTypeJSON.addProperty("id", serviceType.id)
+
+                    serviceType.serviceObjectTypes.forEach { serviceObjectType ->
+                        val serviceObjectTypeJSON = JsonObject()
+                        serviceObjectTypeJSON.addProperty("id", serviceObjectType.id)
+
+                        if (serviceObjectTypeJSON.size() > 0)
+                            serviceObjectTypesJSON.add(serviceObjectTypeJSON)
+                    }
+
+                    if (serviceObjectTypesJSON.count() > 0) {
+                        serviceTypeJSON.add("serviceObjectTypes", serviceObjectTypesJSON)
+                        serviceTypesJSON.add(serviceTypeJSON)
+                    }
+                }
+                if (serviceTypesJSON.count() > 0) {
+                    serviceGroupJSON.add("serviceTypes", serviceTypesJSON)
+                    serviceGroupsJSON.add(serviceGroupJSON)
+                }
+            }
+
+            if(serviceGroupsJSON.count() == 0)
+                DMELog.e("Invalid scope service groups format.")
+
+            return serviceGroupsJSON
+        } else
+            return JsonArray()
+    }
+
     private fun serializeDataRequest(src: DMEDataRequest): JsonObject {
 
         val json = JsonObject()
 
-        val timeRangesJSON = JsonArray()
+        val timeRangesJSON = serializeTimeRanges(src)
+        val serviceGroupsJSON = serializeServiceGroups(src)
 
-        src.timeRanges.forEach { timeRange ->
-            val timeRangeJSON = JsonObject()
-
-            val timeFrom = timeRange.from
-            val timeTo = timeRange.to
-            val timeLast = timeRange.last
-
-            if (timeLast != null) {
-                timeRangeJSON.addProperty("last", timeLast)
-            }
-            else if (timeFrom != null && timeTo != null) {
-                timeRangeJSON.addProperty("from", timeFrom.time)
-                timeRangeJSON.addProperty("to", timeTo.time)
-            }
-
-            if (timeRangeJSON.size() > 0) {
-                timeRangesJSON.add(timeRangeJSON)
-            }
+        if (serviceGroupsJSON.count() > 0) {
+            json.add("serviceGroups", serviceGroupsJSON)
         }
 
         if (timeRangesJSON.count() > 0) {

--- a/sdk/src/main/java/me/digi/sdk/api/interceptors/DMERetryInterceptor.kt
+++ b/sdk/src/main/java/me/digi/sdk/api/interceptors/DMERetryInterceptor.kt
@@ -3,7 +3,6 @@ package me.digi.sdk.api.interceptors
 import me.digi.sdk.entities.DMEClientConfiguration
 import okhttp3.Interceptor
 import okhttp3.Response
-import okhttp3.internal.lockAndWaitNanos
 import okhttp3.internal.waitMillis
 
 class DMERetryInterceptor(private val config: DMEClientConfiguration): Interceptor {
@@ -19,30 +18,40 @@ class DMERetryInterceptor(private val config: DMEClientConfiguration): Intercept
 
         var retryAttemptsRemaining = config.maxRetryCount
 
-        // All the while the request fails, retry it if below cap.
-        while (!response.isSuccessful && retryAttemptsRemaining > 0) {
+        if(isRecoverableError(response)) {
+            // All the while the request fails, retry it if below cap.
+            while (!response.isSuccessful && retryAttemptsRemaining > 0) {
 
-            retryAttemptsRemaining--
+                retryAttemptsRemaining--
 
-            val waitTime = {
-                var t = config.retryDelay.toLong()
+                val waitTime = {
+                    var t = config.retryDelay.toLong()
 
-                if (config.retryWithExponentialBackOff) {
-                    repeat(config.maxRetryCount - retryAttemptsRemaining) { t*=2 }
+                    if (config.retryWithExponentialBackOff) {
+                        repeat(config.maxRetryCount - retryAttemptsRemaining) { t *= 2 }
+                    }
+
+                    t
+                }.invoke()
+
+                // TODO: Implement error based filtering to avoid non-recoverable retries.
+                synchronized(request) {
+                    request.waitMillis(waitTime)
                 }
 
-                t
-            }.invoke()
-
-            // TODO: Implement error based filtering to avoid non-recoverable retries.
-            synchronized(request) {
-                request.waitMillis(waitTime)
+                response.close()
+                response = chain.proceed(request)
             }
-
-            response.close()
-            response = chain.proceed(request)
         }
 
         return response
+    }
+
+    private fun isRecoverableError(response: Response) :Boolean
+    {
+        return when(response.code) {
+            400, 401 -> false
+            else -> true
+        }
     }
 }

--- a/sdk/src/main/java/me/digi/sdk/entities/DMEDataRequest.kt
+++ b/sdk/src/main/java/me/digi/sdk/entities/DMEDataRequest.kt
@@ -2,8 +2,12 @@ package me.digi.sdk.entities
 
 interface DMEDataRequest {
 
+    var serviceGroups: List<DMEServiceGroup>
+
     var timeRanges: List<DMETimeRange>
 
     val context: String
 
+    fun serviceGroupsInitialized(): Boolean
+    fun timeRangesInitialized(): Boolean
 }

--- a/sdk/src/main/java/me/digi/sdk/entities/DMEScope.kt
+++ b/sdk/src/main/java/me/digi/sdk/entities/DMEScope.kt
@@ -2,7 +2,14 @@ package me.digi.sdk.entities
 
 class DMEScope: DMEDataRequest {
 
+    override lateinit var serviceGroups: List<DMEServiceGroup>
+
     override lateinit var timeRanges: List<DMETimeRange>
 
     override val context: String = "scope" // Context defaults to 'scope'.
+
+    override fun serviceGroupsInitialized() = ::serviceGroups.isInitialized
+
+    override fun timeRangesInitialized() = ::timeRanges.isInitialized
+
 }

--- a/sdk/src/main/java/me/digi/sdk/entities/DMEServiceGroup.kt
+++ b/sdk/src/main/java/me/digi/sdk/entities/DMEServiceGroup.kt
@@ -1,0 +1,6 @@
+package me.digi.sdk.entities
+
+class DMEServiceGroup (
+    val id: Int,
+    val serviceTypes: List<DMEServiceType>
+)

--- a/sdk/src/main/java/me/digi/sdk/entities/DMEServiceObjectType.kt
+++ b/sdk/src/main/java/me/digi/sdk/entities/DMEServiceObjectType.kt
@@ -1,0 +1,5 @@
+package me.digi.sdk.entities
+
+class DMEServiceObjectType (
+    val id: Int
+)

--- a/sdk/src/main/java/me/digi/sdk/entities/DMEServiceType.kt
+++ b/sdk/src/main/java/me/digi/sdk/entities/DMEServiceType.kt
@@ -1,0 +1,6 @@
+package me.digi.sdk.entities
+
+class DMEServiceType (
+    val id: Int,
+    val serviceObjectTypes: List<DMEServiceObjectType>
+)

--- a/sdk/src/main/java/me/digi/sdk/entities/DMETimeRange.kt
+++ b/sdk/src/main/java/me/digi/sdk/entities/DMETimeRange.kt
@@ -6,6 +6,6 @@ class DMETimeRange (
 
     val from: Date?,
     val to: Date?,
-    val last: String?
-
+    val last: String?,
+    val type: String?
 )

--- a/sdk/src/test/java/me/digi/sdk/tests/api/helpers/adapters/DMESessionRequestAdapterSpec.kt
+++ b/sdk/src/test/java/me/digi/sdk/tests/api/helpers/adapters/DMESessionRequestAdapterSpec.kt
@@ -1,0 +1,161 @@
+package me.digi.sdk.tests.api.helpers.adapters
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonSerializationContext
+import me.digi.sdk.api.adapters.DMESessionRequestAdapter
+import me.digi.sdk.entities.*
+import me.digi.sdk.entities.api.DMESessionRequest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import com.google.gson.JsonElement
+import com.google.gson.Gson
+import io.mockk.*
+import org.junit.Before
+
+@RunWith(RobolectricTestRunner::class)
+class DMESessionRequestAdapterSpec {
+
+    private var dummyScope: DMEScope = DMEScope()
+    private val mockContext = mockk<JsonSerializationContext>(relaxed = true)
+    private val test = JsonObject()
+    private val gson = Gson()
+
+
+    @Before
+    fun setup() {
+        dummyScope = DMEScope()
+        test.addProperty("dummy", "dummy")
+        every { mockContext.serialize(any()) } returns test
+    }
+
+    @Test
+    fun `given a valid scope format, service groups and time ranges are serialized`() {
+        val serviceObjectTypes: List<DMEServiceObjectType> =
+            listOf(DMEServiceObjectType(1), DMEServiceObjectType(2), DMEServiceObjectType(7))
+        val serviceTypes: List<DMEServiceType> = listOf(DMEServiceType(4, serviceObjectTypes))
+        val serviceGroups: List<DMEServiceGroup> = listOf(DMEServiceGroup(2, serviceTypes))
+
+        dummyScope.serviceGroups = serviceGroups
+        dummyScope.timeRanges = listOf(DMETimeRange(null, null, null, "all"))
+
+        val actualResult = DMESessionRequestAdapter.serialize(
+            DMESessionRequest(
+                "dummyAppId",
+                "dummyContractId",
+                DMESDKAgent(),
+                "gzip",
+                dummyScope
+            ), null, mockContext
+        )
+
+        val expectedResult = gson.fromJson(
+            "{\"appId\":\"dummyAppId\",\"contractId\":\"dummyContractId\",\"accept\":{\"dummy\":\"dummy\"},\"sdkAgent\":{\"dummy\":\"dummy\"},\"scope\":{\"serviceGroups\":[{\"id\":2,\"serviceTypes\":[{\"id\":4,\"serviceObjectTypes\":[{\"id\":1},{\"id\":2},{\"id\":7}]}]}],\"timeRanges\":[{\"type\":\"all\"}]}}",
+            JsonElement::class.java
+        )
+
+        assertEquals(actualResult, expectedResult)
+    }
+
+    @Test
+    fun `given an invalid scope format for service types, time ranges are serialized`() {
+        val serviceTypes: List<DMEServiceType> = listOf()
+        val serviceGroups: List<DMEServiceGroup> = listOf(DMEServiceGroup(2, serviceTypes))
+
+        dummyScope.serviceGroups = serviceGroups
+        dummyScope.timeRanges = listOf(DMETimeRange(null, null, null, "all"))
+
+        val actualResult = DMESessionRequestAdapter.serialize(
+            DMESessionRequest(
+                "dummyAppId",
+                "dummyContractId",
+                DMESDKAgent(),
+                "gzip",
+                dummyScope
+            ), null, mockContext
+        )
+
+        val expectedResult = gson.fromJson(
+            "{\"appId\":\"dummyAppId\",\"contractId\":\"dummyContractId\",\"accept\":{\"dummy\":\"dummy\"},\"sdkAgent\":{\"dummy\":\"dummy\"},\"scope\":{\"timeRanges\":[{\"type\":\"all\"}]}}",
+            JsonElement::class.java
+        )
+
+        assertEquals(actualResult, expectedResult)
+    }
+
+    @Test
+    fun `given an invalid scope format for service object types, time ranges are serialized`() {
+        val serviceObjectTypes: List<DMEServiceObjectType> = mutableListOf()
+        val serviceTypes: List<DMEServiceType> = listOf(DMEServiceType(4, serviceObjectTypes))
+        val serviceGroups: List<DMEServiceGroup> = listOf(DMEServiceGroup(2, serviceTypes))
+
+        dummyScope.serviceGroups = serviceGroups
+        dummyScope.timeRanges = listOf(DMETimeRange(null, null, null, "all"))
+
+        val actualResult = DMESessionRequestAdapter.serialize(
+            DMESessionRequest(
+                "dummyAppId",
+                "dummyContractId",
+                DMESDKAgent(),
+                "gzip",
+                dummyScope
+            ), null, mockContext
+        )
+
+        val expectedResult = gson.fromJson(
+            "{\"appId\":\"dummyAppId\",\"contractId\":\"dummyContractId\",\"accept\":{\"dummy\":\"dummy\"},\"sdkAgent\":{\"dummy\":\"dummy\"},\"scope\":{\"timeRanges\":[{\"type\":\"all\"}]}}",
+            JsonElement::class.java
+        )
+
+        assertEquals(actualResult, expectedResult)
+    }
+
+    @Test
+    fun `given an empty scope format for time ranges, service groups are serialized`() {
+        val serviceObjectTypes: List<DMEServiceObjectType> = listOf(DMEServiceObjectType(1), DMEServiceObjectType(2), DMEServiceObjectType(7))
+        val serviceTypes: List<DMEServiceType> = listOf(DMEServiceType(4, serviceObjectTypes))
+        val serviceGroups: List<DMEServiceGroup> = listOf(DMEServiceGroup(2, serviceTypes))
+
+        dummyScope.serviceGroups = serviceGroups
+
+        val actualResult = DMESessionRequestAdapter.serialize(
+            DMESessionRequest(
+                "dummyAppId",
+                "dummyContractId",
+                DMESDKAgent(),
+                "gzip",
+                dummyScope
+            ), null, mockContext
+        )
+
+        val expectedResult = gson.fromJson(
+            "{\"appId\":\"dummyAppId\",\"contractId\":\"dummyContractId\",\"accept\":{\"dummy\":\"dummy\"},\"sdkAgent\":{\"dummy\":\"dummy\"},\"scope\":{\"serviceGroups\":[{\"id\":2,\"serviceTypes\":[{\"id\":4,\"serviceObjectTypes\":[{\"id\":1},{\"id\":2},{\"id\":7}]}]}]}}",
+            JsonElement::class.java
+        )
+
+        assertEquals(actualResult, expectedResult)
+    }
+
+    @Test
+    fun `given an empty scope format for service groups, time ranges are serialized`() {
+        dummyScope.timeRanges = listOf(DMETimeRange(null, null, null, "all"))
+
+        val actualResult = DMESessionRequestAdapter.serialize(
+            DMESessionRequest(
+                "dummyAppId",
+                "dummyContractId",
+                DMESDKAgent(),
+                "gzip",
+                dummyScope
+            ), null, mockContext
+        )
+
+        val expectedResult = gson.fromJson(
+            "{\"appId\":\"dummyAppId\",\"contractId\":\"dummyContractId\",\"accept\":{\"dummy\":\"dummy\"},\"sdkAgent\":{\"dummy\":\"dummy\"},\"scope\":{\"timeRanges\":[{\"type\":\"all\"}]}}",
+            JsonElement::class.java
+        )
+
+        assertEquals(actualResult, expectedResult)
+    }
+}


### PR DESCRIPTION
- CA Scope added, `DMEScope` is expanded by adding `DMEServiceGroup`, `DMEServiceType` and `DMEServiceObjectType`
- Filtering of non-recoverable error added in `DMERetryInterceptor`
- Possible `ScopeOutOfBounds` API error, which occurs if the user is asking for data that is out of bounds defined by the contract, handled within `DMEAPIError` and is treated as an non-recoverable error
- Added tests for `DMESessionRequestAdapter` 
- Custom test application is prepared for QA team 