### PR TITLE
[DIGI-18953] - Consistent set of errors on SDK

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/sdk/src/main/java/me/digi/sdk/DMEError.kt
+++ b/sdk/src/main/java/me/digi/sdk/DMEError.kt
@@ -34,8 +34,8 @@ sealed class DMEAuthError(override val message: String) : DMEError(message) {
 annotation class ArgonCode(val value: String)
 sealed class DMEAPIError(
     internal var code: String? = null,
-    override val message: String,
-    internal val reference: String? = null
+    override var message: String,
+    internal var reference: String? = null
 
 ) : DMEError(message) {
 
@@ -61,6 +61,6 @@ sealed class DMEAPIError(
     @ArgonCode("SessionUpdateFailed") class SESSION_UPDATE_FAILED: DMEAPIError()
 
     class UNMAPPED(argonCode: String, argonMessage: String?, argonReference: String?): DMEAPIError(argonCode, argonMessage!!, argonReference)
-    class GENERIC(httpStatusCode: Int, message: String): DMEAPIError(message = "Http Status: $httpStatusCode - Error: $message")
+    class GENERIC(httpStatusCode: Int, message: String): DMEAPIError(message = "Http Status: $httpStatusCode\nError: $message")
     class UNREACHABLE : DMEAPIError(message = "Couldn't reach the digi.me API - please check your network connection.")
 }

--- a/sdk/src/main/java/me/digi/sdk/DMEError.kt
+++ b/sdk/src/main/java/me/digi/sdk/DMEError.kt
@@ -1,49 +1,66 @@
 package me.digi.sdk
 
-abstract class DMEError(override val message: String): Throwable(message)
+abstract class DMEError(override val message: String) : Throwable(message)
 
-sealed class DMESDKError(override val message: String): DMEError(message) {
+sealed class DMESDKError(override val message: String) : DMEError(message) {
 
-    class NoContract(): DMESDKError("Contract ID not set.")
-    class InvalidContract(): DMESDKError("Contract ID is not in a valid format.")
-    class DecryptionFailed(): DMESDKError("Could not decrypt the file content.")
-    class EncryptionFailed(): DMESDKError("Could not encrypt the file content.")
-    class InvalidData(): DMESDKError("Could not deserialise the file content.")
-    class InvalidVersion(): DMESDKError("Current version of SDK no longer supported.")
-    class NoAppID(): DMESDKError("App ID not set.")
-    class P12ParsingError(): DMESDKError("Could not parse the P12 file with supplied password, or no P12/password given.")
-    class NoURLScheme(): DMESDKError("Intent filter for URL scheme (for callbacks) not found.")
-    class DigiMeAppNotFound(): DMESDKError("Querying digime schema failed. (digi.me app not installed.)")
-    class CommunicatorNotInitialized(): DMESDKError("DMEAppCommunicator shared instance accessed before initialization.")
-    class InvalidContext(): DMESDKError("Given context is not the application context; ONLY the application context may be used.")
-    class FileListPollingTimeout(): DMESDKError("File List time out has been reached as there have been no changes during the number of retries specified in `DMEPullConfiguration`.")
+    class NoContract : DMESDKError("No contracts registered! You must have forgotten to set contractId property on the configuration object.")
+    class InvalidContract : DMESDKError("Provided contractId has invalid format.")
+    class DecryptionFailed : DMESDKError("Could not decrypt file content.")
+    class EncryptionFailed : DMESDKError("Could not encrypt the file content.")
+    class InvalidData : DMESDKError("Could not serialize data.")
+    class InvalidVersion : DMESDKError("This SDK version is no longer supported.  Please update to a newer version.")
+    class NoAppID : DMESDKError("No application registered! Please set appId property on the configuration object.")
+    class P12ParsingError : DMESDKError("Could not parse the P12 file with supplied password, or no P12/password given.")
+    class NoURLScheme : DMESDKError("Intent filter for URL scheme (for callbacks) not found.")
+    class DigiMeAppNotFound : DMESDKError("DigiMe app is not installed")
+    class CommunicatorNotInitialized : DMESDKError("DMEAppCommunicator shared instance accessed before initialization.")
+    class InvalidContext : DMESDKError("Given context is not the application context; ONLY the application context may be used.")
+    class FileListPollingTimeout : DMESDKError("File List time out reached as there have been no changes during the number of retries specified in `DMEPullConfiguration`.")
+}
+
+sealed class DMEAuthError(override val message: String) : DMEError(message) {
+
+    class General : DMEAuthError("Unknown authorization error has occurred.")
+    class Cancelled : DMEAuthError("User cancelled authorization.")
+    class InvalidSession : DMEAuthError("The session key is invalid or has expired.")
+    class InvalidSessionKey : DMEAuthError("digi.me app returned an invalid session key.")
+    class TokenExpired : DMEAuthError("The refresh token supplied has expired. As `autoRecoverExpiredCredentials` is turned off, you will need to repeat authorization without credentials to recover.")
 
 }
 
-sealed class DMEAuthError(override val message: String): DMEError(message) {
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ArgonCode(val value: String)
+sealed class DMEAPIError(
+    internal var code: String? = null,
+    override val message: String,
+    internal val reference: String? = null
 
-    class General(): DMEAuthError("An unknown authorisation error has occurred.")
-    class Cancelled(): DMEAuthError("The user cancelled the authorisation action.")
-    class InvalidSession(): DMEAuthError("The session key is invalid or has expired.")
-    class InvalidSessionKey(): DMEAuthError("The session key provided to the digi.me app is not valid.")
-    class TokenExpired(): DMEAuthError("The refresh token supplied has expired. As `autoRecoverExpiredCredentials` is turned off, you will need to repeat authorization without credentials to recover.")
+) : DMEError(message) {
 
-}
+    constructor(): this(null, "", null)
+    constructor(argonCode: String): this(argonCode, "", null)
 
-sealed class DMEAPIError(override val message: String,
-                         internal val reference: String? = null,
-                         internal val code: String? = null): DMEError(message) {
+    init {
+        if (code == null) {
+            // No override provided, try to parse annotation.
+            code = (this::class.annotations.firstOrNull { it is ArgonCode } as? ArgonCode)?.value
+        }
+    }
 
-    class Generic(): DMEAPIError("There was a problem with your request.")
-    class Server(message: String, reference: String?, code: String?): DMEAPIError(message, reference, code)
-    class Unreachable(): DMEAPIError("Couldn't reach the digi.me API - please check your network connection.")
-    class InvalidSyncState(): DMEAPIError("An invalid sync syncStatus was returned - please try again.")
-    class PartialSync(): DMEAPIError("One or more accounts failed to sync. Some data has been delivered.")
-    class TokenInvalid(): DMEAPIError("The provided refresh token is invalid.")
-    class TokenNotYetValid(): DMEAPIError("The provided token is not yet valid.")
-    class TooManyRequest(): DMEAPIError("Rate limiting is enforced and this request exceeds the configured limit.")
-    class SessionInvalid(): DMEAPIError("Session state does not exist.")
-    class SessionUsed(): DMEAPIError("Session has already been consumed.")
-    class SessionUpdateFailed(): DMEAPIError("Unable to update the PUA object.")
+    @ArgonCode("InvalidPCloud") class INVALID_PCLOUD: DMEAPIError()
+    @ArgonCode("InvalidRefreshToken") class INVALID_REFRESH_TOKEN: DMEAPIError()
+    @ArgonCode("InvalidSyncState") class INVALID_SYNC_STATE : DMEAPIError()
+    @ArgonCode("PartialSync") class PARTIAL_SYNC : DMEAPIError()
+    @ArgonCode("TokenInvalid") class INVALID_TOKEN: DMEAPIError()
+    @ArgonCode("TokenNotYetValid") class TOKEN_NOT_YET_VALID: DMEAPIError()
+    @ArgonCode("TooManyRequests") class TOO_MANY_REQUESTS : DMEAPIError()
+    @ArgonCode("SessionInvalid") class SESSION_INVALID: DMEAPIError()
+    @ArgonCode("SessionUsed") class SESSION_USED: DMEAPIError()
+    @ArgonCode("SessionUpdateFailed") class SESSION_UPDATE_FAILED: DMEAPIError()
 
+    class UNMAPPED(argonCode: String, argonMessage: String?, argonReference: String?): DMEAPIError(argonCode, argonMessage!!, argonReference)
+    class GENERIC(httpStatusCode: Int, message: String): DMEAPIError(message = "Http Status: $httpStatusCode - Error: $message")
+    class UNREACHABLE : DMEAPIError(message = "Couldn't reach the digi.me API - please check your network connection.")
 }

--- a/sdk/src/main/java/me/digi/sdk/DMEPullClient.kt
+++ b/sdk/src/main/java/me/digi/sdk/DMEPullClient.kt
@@ -229,7 +229,7 @@ class DMEPullClient(val context: Context, val configuration: DMEPullConfiguratio
 
                 // If an error is encountered from this call, we inspect it to see if it's an
                 // 'InvalidToken' error, meaning that the ACCESS token has expired.
-                if (error is DMEAPIError.Server && error.code == "InvalidToken") {
+                if (error is DMEAPIError.INVALID_REFRESH_TOKEN && error.code == "InvalidToken") {
 
                     // If so, we take the active session and expired credentials and try to refresh them.
                     Single.just(Pair(nativeConsentManager.sessionManager.currentSession!!, activeCredentials!!))
@@ -239,7 +239,7 @@ class DMEPullClient(val context: Context, val configuration: DMEPullConfiguratio
 
                             // If an error is encountered from this call, we inspect it to see if it's an
                             // 'InvalidToken' error, meaning that the REFRESH token has expired.
-                            if (error is DMEAPIError.Server && error.code == "InvalidToken") {
+                            if (error is DMEAPIError.INVALID_REFRESH_TOKEN && error.code == "InvalidToken") {
 
                                 // If so, we need to obtain a new set of credentials from the digi.me
                                 // application. Process the flow as before, for ongoing acces, provided
@@ -277,7 +277,7 @@ class DMEPullClient(val context: Context, val configuration: DMEPullConfiguratio
             .subscribe({ result ->
                 completion(result.first, result.second, null)
             }, { error ->
-                completion(null, null, error.let { it as? DMEError } ?: DMEAPIError.Generic())
+                completion(null, null, error.let { it as? DMEError } ?: DMEAPIError.GENERIC(0, error.localizedMessage))
             })
             .addTo(compositeDisposable)
     }

--- a/sdk/src/main/java/me/digi/sdk/api/DMEAPIClient.kt
+++ b/sdk/src/main/java/me/digi/sdk/api/DMEAPIClient.kt
@@ -127,7 +127,17 @@ class DMEAPIClient(private val context: Context, private val clientConfig: DMECl
 
         return DMEAPIError::class.sealedSubclasses.fold<KClass<out DMEAPIError>, DMEAPIError?>(null) { _, err ->
             val argonCode = (err.annotations.firstOrNull { it is ArgonCode } as? ArgonCode)?.value
-            if (argonCode == argonErrorCode) run { return@fold err.createInstance() } else null
+            if (argonCode == argonErrorCode) run {
+                val instance = err.createInstance()
+                instance.apply {
+                    code = argonErrorCode
+                    if (argonErrorMessage != null) message = argonErrorMessage
+                    reference = argonErrorReference
+                }
+
+                return@fold instance
+
+            } else null
         } ?: DMEAPIError.UNMAPPED(argonErrorCode, argonErrorMessage, argonErrorReference)
     }
 }

--- a/sdk/src/main/java/me/digi/sdk/api/interceptors/DMERetryInterceptor.kt
+++ b/sdk/src/main/java/me/digi/sdk/api/interceptors/DMERetryInterceptor.kt
@@ -5,7 +5,7 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import okhttp3.internal.waitMillis
 
-class DMERetryInterceptor(private val config: DMEClientConfiguration): Interceptor {
+class DMERetryInterceptor(private val config: DMEClientConfiguration) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
 
         // Run request.
@@ -18,7 +18,7 @@ class DMERetryInterceptor(private val config: DMEClientConfiguration): Intercept
 
         var retryAttemptsRemaining = config.maxRetryCount
 
-        if(isRecoverableError(response)) {
+        if (isRecoverableError(response)) {
             // All the while the request fails, retry it if below cap.
             while (!response.isSuccessful && retryAttemptsRemaining > 0) {
 
@@ -47,11 +47,8 @@ class DMERetryInterceptor(private val config: DMEClientConfiguration): Intercept
         return response
     }
 
-    private fun isRecoverableError(response: Response) :Boolean
-    {
-        return when(response.code) {
-            400, 401 -> false
-            else -> true
-        }
+    private fun isRecoverableError(response: Response) = when (response.code) {
+        400, 401 -> false
+        else -> true
     }
 }


### PR DESCRIPTION
This ticket was about having consistent set of errors between platforms due to better information sharing in case something goes wrong, to have clearer idea on what specifically went wrong. At least that's the idea.

So only few minor changes happened here since there's few tickets. Essentially SDK general errors, Auth Errors and Argon errors (almost) are updated to be either specific in most cases or rarely generic ones.

Ticket is still kinda work in progress so leave comments, suggestions etc.