### PR TITLE
[DIGI-18956] Update SDK errors based on client

### DIFF
--- a/sdk/src/main/java/me/digi/sdk/DMEError.kt
+++ b/sdk/src/main/java/me/digi/sdk/DMEError.kt
@@ -59,7 +59,7 @@ sealed class DMEAPIError(
     @ArgonCode("SessionUsed") class SESSION_USED: DMEAPIError()
     @ArgonCode("SessionUpdateFailed") class SESSION_UPDATE_FAILED: DMEAPIError()
 
-    class UNMAPPED(argonCode: String?, argonMessage: String, argonReference: String?): DMEAPIError(argonCode, argonMessage, argonReference)
-    class GENERIC(httpStatusCode: Int, message: String): DMEAPIError(message = "Http Status: $httpStatusCode\nError: $message")
+    class UNMAPPED(argonCode: String? = "", argonMessage: String = "", argonReference: String? = ""): DMEAPIError(argonCode, argonMessage, argonReference)
+    class GENERIC(httpStatusCode: Int? = 0, message: String? = ""): DMEAPIError(message = "Http Status: $httpStatusCode\nError: $message")
     class UNREACHABLE : DMEAPIError(message = "Couldn't reach the digi.me API - please check your network connection.")
 }

--- a/sdk/src/main/java/me/digi/sdk/DMEError.kt
+++ b/sdk/src/main/java/me/digi/sdk/DMEError.kt
@@ -26,6 +26,7 @@ sealed class DMEAuthError(override val message: String) : DMEError(message) {
     class InvalidSession : DMEAuthError("The session key is invalid or has expired.")
     class InvalidSessionKey : DMEAuthError("digi.me app returned an invalid session key.")
     class TokenExpired : DMEAuthError("The refresh token supplied has expired. As `autoRecoverExpiredCredentials` is turned off, you will need to repeat authorization without credentials to recover.")
+    class PlaceHolderError(message: String) : DMEAuthError(message)
 
 }
 
@@ -60,7 +61,7 @@ sealed class DMEAPIError(
     @ArgonCode("SessionUsed") class SESSION_USED: DMEAPIError()
     @ArgonCode("SessionUpdateFailed") class SESSION_UPDATE_FAILED: DMEAPIError()
 
-    class UNMAPPED(argonCode: String, argonMessage: String?, argonReference: String?): DMEAPIError(argonCode, argonMessage!!, argonReference)
+    class UNMAPPED(argonCode: String?, argonMessage: String, argonReference: String?): DMEAPIError(argonCode, argonMessage, argonReference)
     class GENERIC(httpStatusCode: Int, message: String): DMEAPIError(message = "Http Status: $httpStatusCode\nError: $message")
     class UNREACHABLE : DMEAPIError(message = "Couldn't reach the digi.me API - please check your network connection.")
 }

--- a/sdk/src/main/java/me/digi/sdk/DMEError.kt
+++ b/sdk/src/main/java/me/digi/sdk/DMEError.kt
@@ -26,8 +26,6 @@ sealed class DMEAuthError(override val message: String) : DMEError(message) {
     class InvalidSession : DMEAuthError("The session key is invalid or has expired.")
     class InvalidSessionKey : DMEAuthError("digi.me app returned an invalid session key.")
     class TokenExpired : DMEAuthError("The refresh token supplied has expired. As `autoRecoverExpiredCredentials` is turned off, you will need to repeat authorization without credentials to recover.")
-    class PlaceHolderError(message: String) : DMEAuthError(message)
-
 }
 
 @Target(AnnotationTarget.CLASS)

--- a/sdk/src/main/java/me/digi/sdk/interapp/managers/DMENativeConsentManager.kt
+++ b/sdk/src/main/java/me/digi/sdk/interapp/managers/DMENativeConsentManager.kt
@@ -7,7 +7,7 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import me.digi.sdk.DMEAuthError
 import me.digi.sdk.R
-import me.digi.sdk.api.DMEAPIClient.Companion.parsedDMEError
+import me.digi.sdk.api.DMEAPIClient.Companion.parseDMEError
 import me.digi.sdk.callbacks.DMEAuthorizationCompletion
 import me.digi.sdk.interapp.DMEAppCallbackHandler
 import me.digi.sdk.interapp.DMEAppCommunicator
@@ -128,16 +128,7 @@ class DMENativeConsentManager(val sessionManager: DMESessionManager, val appId: 
         } else when (result) {
             ctx.getString(R.string.const_result_error) -> {
                 DMELog.e("There was a problem requesting consent.")
-
-                errorMessage?.let {
-                    errorCode?.let {
-                        parsedDMEError(
-                            errorCode,
-                            errorMessage,
-                            errorReference
-                        )
-                    }
-                }
+                parseDMEError(errorCode, errorMessage, errorReference)
             }
             ctx.getString(R.string.const_result_cancel) -> {
                 DMELog.e("User rejected consent request.")


### PR DESCRIPTION
This ticket is for parsing argon errors from client back to the SDK. In our case we have 2 scenarios, one for deducing error from the response, other for parsing raw error which we get back from the client and there we try to figure out is it argon error or an unmapped one (still the same, but mapped ones provide bit more context I suppose).
This is init commit so changes are probably needed.