### PR TITLE
Trigger data query request failing

### DIFF
--- a/sdk/src/main/java/me/digi/sdk/api/DMEAPIClient.kt
+++ b/sdk/src/main/java/me/digi/sdk/api/DMEAPIClient.kt
@@ -85,6 +85,7 @@ class DMEAPIClient(private val context: Context, private val clientConfig: DMECl
             .addInterceptor(DMERetryInterceptor(clientConfig))
             .configureCertificatePinningIfNecessary()
             .callTimeout(clientConfig.globalTimeout.toLong(), TimeUnit.SECONDS)
+            .readTimeout(clientConfig.globalTimeout.toLong(), TimeUnit.SECONDS)
             .dispatcher(requestDispatcher)
 
         val retrofitBuilder = Retrofit.Builder()


### PR DESCRIPTION
- Data query request was failing due to the default read timeout within the http client which is 10 seconds. 
- According to that every response that takes longer then 10 seconds is considered as failed due to timeout.
- Read timeout is now set at the value of the global timeout (62 seconds)